### PR TITLE
Specified dependency on Jinja2>=2.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
 
 requires = [
     'pyramid>=1.0',
-    'Jinja2'
+    'Jinja2>=2.5.0'
 ]
 
 setup(name='pyramid_jinja2',


### PR DESCRIPTION
Specified dependency on Jinja2>=2.5.0, as pyramid_jinja2 depends on jinja2.Environment.install_gettext_callables method added in that version

Can be particularly annoying for those running their own PyPi repositories behind firewall with outdated Jinja2 packages (<2.5)
