### PR TITLE
fix indentation level for Jinja2ProjectTemplate in scaffolds/__init__.py

### DIFF
--- a/pyramid_jinja2/scaffolds/__init__.py
+++ b/pyramid_jinja2/scaffolds/__init__.py
@@ -11,7 +11,7 @@ except ImportError: # pragma: no cover
         paste_script_template_renderer = None
         from pyramid.scaffolds import PyramidTemplate
 
-    class Jinja2ProjectTemplate(PyramidTemplate):
-        _template_dir = 'jinja2_starter'
-        summary = 'pyramid jinja2 starter project'
-        template_renderer = staticmethod(paste_script_template_renderer)
+class Jinja2ProjectTemplate(PyramidTemplate):
+    _template_dir = 'jinja2_starter'
+    summary = 'pyramid jinja2 starter project'
+    template_renderer = staticmethod(paste_script_template_renderer)


### PR DESCRIPTION
Note that this change has not been tested, but I think it makes sense because if paste_script_template_renderer and PyramidTemplate can be found, Jinja2ProjectTemplate will not be defined.
