### PR TITLE
Add *.jinja2 to scaffold MANIFEST.in and mention it in the docs.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,6 +119,13 @@ To setup the Jinja2 search path either one of the following steps must be taken:
     to the root of the app and then it will try the path relative
     to the current package.
 
+Finally, to make sure your :file:`.jinja2` template files are included in your
+package's source distribution (e.g. when using ``python setup.py sdist``), add
+``*.jinja2`` to your :file:`MANIFEST.in`::
+
+  recursive-include yourapp *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.jinja2 *.js *.html *.xml
+
+
 .. _usage:
 
 Usage

--- a/pyramid_jinja2/scaffolds/jinja2_starter/MANIFEST.in_tmpl
+++ b/pyramid_jinja2/scaffolds/jinja2_starter/MANIFEST.in_tmpl
@@ -1,2 +1,2 @@
 include *.txt *.ini *.cfg *.rst
-recursive-include {{package}} *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.js *.html *.xml
+recursive-include {{package}} *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.jinja2 *.js *.html *.xml


### PR DESCRIPTION
This is an improved version (imho) of PR #62 by @samuelololol.

It adds the "*.jinja2" to the MANIFEST.in of the starter project template (scaffold) and also mentions in the docs that this is required to have the files in the source distribution.
