### PR TITLE
Add third option to enable pyramid_jinja2. Promote scaffold.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,8 +30,8 @@ Setup
   If you start a project from scratch, consider using the :ref:`project template <jinja2_starter_template>`
   which comes with a working setup and sensible defaults.
 
-There are two ways to make sure that ``pyramid_jinja2`` is active.  Both
-are completely equivalent:
+There are multiple ways to make sure that ``pyramid_jinja2`` is active.
+All are completely equivalent:
 
 #) Use the :py:func:`~pyramid_jinja2.includeme` function via :py:meth:`~pyramid.config.Configurator.include`::
 


### PR DESCRIPTION
I added the `pyramid.includes` setting as option number 2 because I thinks it's more common than the ZCML version these days.

Also, as the setup gets longer and longer, I added a short note that promotes the scaffold which is mentioned (much) later in the document. For new users this might be a better place to start with.
