### PR TITLE
setup.py: Change `append` to `extend`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,12 +30,12 @@ requires = [
 ]
 
 if (3,) < sys.version_info < (3, 3):
-    requires.append([
+    requires.extend([
         'Jinja2>=2.5.0,<2.7dev', #2.7 drops Python 3.2 compat.
         'markupsafe<0.16', #0.16 drops Python 3.2 compat
         ])
 else:
-    requires.append([
+    requires.extend([
         'Jinja2>=2.5.0',
         'markupsafe',
         ])


### PR DESCRIPTION
to prevent error when using `python setup.py bdist_wheel`

Without this, I get the following when doing `python setup.py bdist_wheel`:

``` python
Traceback (most recent call last):
  File "setup.py", line 90, in <module>
    """,
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/private/tmp/responsesvc/lib/python2.7/site-packages/wheel/bdist_wheel.py", line 222, in run
    self.distinfo_dir)
  File "/private/tmp/responsesvc/lib/python2.7/site-packages/wheel/bdist_wheel.py", line 387, in egg2dist
    distribution=self.distribution)
  File "/private/tmp/responsesvc/lib/python2.7/site-packages/wheel/metadata.py", line 160, in pkginfo_to_dict
    new_requirements = list(convert_requirements(requirements))
  File "/private/tmp/responsesvc/lib/python2.7/site-packages/wheel/metadata.py", line 215, in convert_requirements
    parsed_requirement = pkg_resources.Requirement.parse(req)
  File "/private/tmp/responsesvc/lib/python2.7/site-packages/pkg_resources.py", line 2620, in parse
    raise ValueError("Expected only one requirement", s)
ValueError: ('Expected only one requirement', ['Jinja2>=2.5.0', 'markupsafe'])
```
