### PR TITLE
Fix capitalization of MarkupSafe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,12 @@ requires = [
 if (3,) < sys.version_info < (3, 3):
     requires.extend([
         'Jinja2>=2.5.0,<2.7dev', #2.7 drops Python 3.2 compat.
-        'markupsafe<0.16', #0.16 drops Python 3.2 compat
+        'MarkupSafe<0.16', #0.16 drops Python 3.2 compat
         ])
 else:
     requires.extend([
         'Jinja2>=2.5.0',
-        'markupsafe',
+        'MarkupSafe',
         ])
 
 try:


### PR DESCRIPTION
Prevents this warning when pip installing:

```
Real name of requirement markupsafe is MarkupSafe
```
