### PR TITLE
Avoid get_current_request where possible

### DIFF
--- a/pyramid_jinja2/filters.py
+++ b/pyramid_jinja2/filters.py
@@ -18,7 +18,7 @@ def model_url_filter(ctx, model, *elements, **kw):
     """A filter from ``model`` to a string representing the absolute URL.
     This filter calls :py:func:`pyramid.url.resource_url`.
     """
-    request = get_current_request()
+    request = ctx.get('request') or get_current_request()
     return resource_url(model, request, *elements, **kw)
 
 
@@ -27,7 +27,7 @@ def route_url_filter(ctx, route_name, *elements, **kw):
     """A filter from ``route_name`` to a string representing the absolute URL.
     This filter calls :py:func:`pyramid.url.route_url`.
     """
-    request = get_current_request()
+    request = ctx.get('request') or get_current_request()
     return route_url(route_name, request, *elements, **kw)
 
 
@@ -36,7 +36,7 @@ def route_path_filter(ctx, route_name, *elements, **kw):
     """A filter from ``route_name`` to a string representing the relative URL.
     This filter calls :py:func:`pyramid.url.route_path`.
     """
-    request = get_current_request()
+    request = ctx.get('request') or get_current_request()
     return route_path(route_name, request, *elements, **kw)
 
 
@@ -45,7 +45,7 @@ def static_url_filter(ctx, path, **kw):
     """A filter from ``path`` to a string representing the absolute URL.
     This filter calls :py:func:`pyramid.url.static_url`.
     """
-    request = get_current_request()
+    request = ctx.get('request') or get_current_request()
     return static_url(path, request, **kw)
 
 
@@ -54,5 +54,5 @@ def static_path_filter(ctx, path, **kw):
     """A filter from ``path`` to a string representing the relative URL.
     This filter calls :py:func:`pyramid.url.static_path`.
     """
-    request = get_current_request()
+    request = ctx.get('request') or get_current_request()
     return static_path(path, request, **kw)


### PR DESCRIPTION
This PR changes the filters so that the magical get_current_request function is only used when the request cannot be retrieved from the context. This conforms better with Pyramid [docs](http://docs.pylonsproject.org/docs/pyramid/en/latest/narr/threadlocals.html#why-you-shouldn-t-abuse-thread-locals) while being robust.

This PR is naturally b/c and falls back to the old code on failure. 
