### PR TITLE
Add resource_path filter

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -546,6 +546,7 @@ Jinja2 Filters
 .. autofunction:: model_url_filter
 .. autofunction:: route_url_filter
 .. autofunction:: static_url_filter
+.. autofunction:: model_path_filter
 .. autofunction:: route_path_filter
 .. autofunction:: static_path_filter
 

--- a/pyramid_jinja2/filters.py
+++ b/pyramid_jinja2/filters.py
@@ -23,6 +23,15 @@ def model_url_filter(ctx, model, *elements, **kw):
 
 
 @contextfilter
+def model_path_filter(ctx, model, *elements, **kw):
+    """A filter from ``model`` to a string representing the relative URL.
+    This filter calls :py:meth:`pyramid.request.Request.resource_path`.
+    """
+    request = ctx.get('request') or get_current_request()
+    return request.resource_path(model, *elements, **kw)
+
+
+@contextfilter
 def route_url_filter(ctx, route_name, *elements, **kw):
     """A filter from ``route_name`` to a string representing the absolute URL.
     This filter calls :py:func:`pyramid.url.route_url`.

--- a/pyramid_jinja2/tests/test_filters.py
+++ b/pyramid_jinja2/tests/test_filters.py
@@ -44,6 +44,22 @@ class Test_model_url_filter(Base, unittest.TestCase):
         rendered = self._callFUT({'model': model}, "{{model|model_url('edit')}}")
         self.assertEqual(rendered, 'http://example.com/dummy/edit')
 
+class Test_model__filter(Base, unittest.TestCase):
+
+    def _addFilters(self):
+        from pyramid_jinja2.filters import model_path_filter
+        self.environment.filters['model_path'] = model_path_filter
+
+    def test_filter(self):
+        model = DummyModel()
+        rendered = self._callFUT({'model': model}, '{{model|model_path}}')
+        self.assertEqual(rendered, '/dummy/')
+
+    def test_filter_with_elements(self):
+        model = DummyModel()
+        rendered = self._callFUT({'model': model}, "{{model|model_path('edit')}}")
+        self.assertEqual(rendered, '/dummy/edit')
+
 class Test_route_url_filter(Base, unittest.TestCase):
     def _addFilters(self):
         from pyramid_jinja2.filters import route_url_filter


### PR DESCRIPTION
I was missing the resource_path filter in the default filters. When implementing I noticed that it seems to be quite new and only exists on the request object.

I tried to maintain as much symmetry with the other filters as possible but I had to use the newer, preferred method on the request object as pyramid.url does not have it.

I just copied the model_url tests and adapted them and also updated the docs to reflect there is a new filter. Let me know if you need anything else.