### PR TITLE
Allow specifying a custom GetTextWrapper

### DIFF
--- a/pyramid_jinja2/settings.py
+++ b/pyramid_jinja2/settings.py
@@ -129,7 +129,10 @@ def parse_env_options_from_settings(settings,
 
     # get supplementary jinja2 settings
     domain = sget('i18n.domain', package and package.__name__ or 'messages')
-    opts['gettext'] = GetTextWrapper(domain=domain)
+    gettext_wrapper = sget('i18n.gettext', GetTextWrapper)
+    if not issubclass(gettext_wrapper, GetTextWrapper):
+        gettext_wrapper = maybe_dotted(gettext_wrapper)
+    opts['gettext'] = gettext_wrapper(domain=domain)
 
     # get jinja2 extensions
     extensions = parse_multiline(sget('extensions', ''))

--- a/pyramid_jinja2/tests/test_settings.py
+++ b/pyramid_jinja2/tests/test_settings.py
@@ -112,6 +112,7 @@ class Test_parse_env_options_from_settings(unittest.TestCase):
         )
 
     def test_most_settings(self):
+        from pyramid_jinja2.i18n import GetTextWrapper
         settings = {
             'j2.block_start_string': '<<<',
             'j2.block_end_string': '>>>',
@@ -144,6 +145,7 @@ class Test_parse_env_options_from_settings(unittest.TestCase):
         self.assertEqual(opts['cache_size'], 300)
         self.assertEqual(opts['gettext'].domain, 'pyramid_jinja2')
         self.assertFalse('finalize' in opts)
+        self.assertTrue(isinstance(opts['gettext'], GetTextWrapper))
 
     def test_finalize(self):
         settings = {
@@ -151,6 +153,19 @@ class Test_parse_env_options_from_settings(unittest.TestCase):
         }
         opts = self._callFUT(settings, 'j2.')
         self.assertTrue(opts['finalize'] is _fake_finalize)
+
+    def test_override_gettext(self):
+        class FakeGettextWrapper(object):
+            def __init__(self, domain):
+                self.domain = domain
+
+        settings = {
+            'j2.i18n.gettext':  FakeGettextWrapper,
+            'j2.i18n.domain': 'testdomain',
+        }
+        opts = self._callFUT(settings, 'j2.')
+        self.assertTrue(isinstance(opts['gettext'], FakeGettextWrapper))
+        self.assertEqual(opts['gettext'].domain, 'testdomain')
 
     def test_strict_undefined(self):
         from jinja2 import StrictUndefined


### PR DESCRIPTION
Another thing I need that I didn't notice... sorry!

This just lets someone to specify their own ``GetTextWrapper`` class allowing people to choose alternate ways of translation.