### PR TITLE
Fix OS Error 22

### DIFF
--- a/pyramid_jinja2/__init__.py
+++ b/pyramid_jinja2/__init__.py
@@ -232,12 +232,16 @@ class SmartAssetSpecLoader(FileSystemLoader):
                         return src
 
         # try to load the template from the default search path
-        try:
-            # avoid recursive includes
-            if template not in rel_chain:
-                return FileSystemLoader.get_source(self, environment, template)
-        except TemplateNotFound:
-            pass
+        for parent in rel_searchpath:
+            try:
+                uri = os.path.join(parent, template)
+                # avoid recursive includes
+                if uri not in rel_chain:
+                    return FileSystemLoader.get_source(self, environment, uri)
+            except TemplateNotFound:
+                pass
+            except OSError:
+                pass
 
         # we're here because of an exception during the last step so extend
         # the message and raise an appropriate error

--- a/pyramid_jinja2/__init__.py
+++ b/pyramid_jinja2/__init__.py
@@ -203,7 +203,7 @@ class SmartAssetSpecLoader(FileSystemLoader):
             src = self._get_absolute_source(template)
             if src is not None:
                 return src
-            else:
+            elif ':' not in template or os.name is not 'nt':
                 # fallback to the search path just incase
                 return FileSystemLoader.get_source(self, environment, template)
 
@@ -236,11 +236,9 @@ class SmartAssetSpecLoader(FileSystemLoader):
             try:
                 uri = os.path.join(parent, template)
                 # avoid recursive includes
-                if uri not in rel_chain:
+                if uri not in rel_chain and (os.name is not 'nt' or ':' not in uri):
                     return FileSystemLoader.get_source(self, environment, uri)
             except TemplateNotFound:
-                pass
-            except OSError:
                 pass
 
         # we're here because of an exception during the last step so extend

--- a/pyramid_jinja2/__init__.py
+++ b/pyramid_jinja2/__init__.py
@@ -232,14 +232,12 @@ class SmartAssetSpecLoader(FileSystemLoader):
                         return src
 
         # try to load the template from the default search path
-        for parent in rel_searchpath:
-            try:
-                uri = os.path.join(parent, template)
-                # avoid recursive includes
-                if uri not in rel_chain:
-                    return FileSystemLoader.get_source(self, environment, uri)
-            except TemplateNotFound:
-                pass
+        try:
+            # avoid recursive includes
+            if template not in rel_chain:
+                return FileSystemLoader.get_source(self, environment, template)
+        except TemplateNotFound:
+            pass
 
         # we're here because of an exception during the last step so extend
         # the message and raise an appropriate error


### PR DESCRIPTION
When using {% extend %} to a non-relative template, it was throwing OS Error 22 due to URIs getting passed in to the FileSystemLoader like '<module>:<template>' which it would attempt to load and error.  The error I was getting was:
OSError: [Errno 22] Invalid argument: 'C:\Users\Example\project\templates\<module>:<template>.jinja2'

The presence of the : in the path would mess it up and throw the error when it attempted to open the file and, since it was an OSError, it was not caught by the normal Except clause in open_if_exists. I merely had to remove the for loop and pass the template itself to the FileSystemLoader and it was able to find and load the template using the default search paths without issue.

Was this a bug or is there a reason it needs to loop through the relative paths when looking up by the default search path that I am missing?
