### PR TITLE
Add jinja2.i18n_extension configuration setting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+- Add ``jinja2.i18n_extension`` configuration setting.
+
 2.9.2 (2022-03-19)
 ==================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -325,8 +325,9 @@ Now ``foo.email`` will be rendered using the ``mail.jinja2.*`` settings.
 Internalization (i18n)
 ----------------------
 
-When :term:`pyramid_jinja2` is included in a Pyramid application,
-:ref:`jinja2.ext.i18n <jinja2:i18n-extension>` is automatically activated.
+When :term:`pyramid_jinja2` is included in a Pyramid application, either
+:ref:`jinja2.ext.i18n <jinja2:i18n-extension>` or the extension configured by
+``jinja2.i18n_extension`` is automatically activated.
 
 Be sure to configure ``jinja2.i18n.domain`` according to ``setup.cfg`` domain
 settings. By default, ``jinja2.i18n.domain`` is set to the name of the
@@ -470,8 +471,18 @@ jinja2.extensions
 -----------------
 
 A list of extension objects, or a newline-delimited set of dotted import
-locations, where each line represents an extension. :ref:`jinja2.ext.i18n
-<jinja2:i18n-extension>` is automatically activated.
+locations, where each line represents an extension. Either :ref:`jinja2.ext.i18n
+<jinja2:i18n-extension>` or the i18n extension configured using
+``jinja2.i18n_extension`` is automatically activated.
+
+
+.. _setting_jinja2_i18n_extension:
+
+jinja2.i18n_extension
+---------------------
+
+The name of the i18n extension to activate. Defaults to
+:ref:`jinja2.ext.i18n <jinja2:i18n-extension>`.
 
 
 .. _setting_jinja2_i18n_domain:

--- a/src/pyramid_jinja2/settings.py
+++ b/src/pyramid_jinja2/settings.py
@@ -136,8 +136,9 @@ def parse_env_options_from_settings(
 
     # get jinja2 extensions
     extensions = parse_multiline(sget("extensions", ""))
-    if "jinja2.ext.i18n" not in extensions:
-        extensions.append("jinja2.ext.i18n")
+    i18n_extension = sget("i18n_extension", "jinja2.ext.i18n")
+    if i18n_extension not in extensions:
+        extensions.append(i18n_extension)
     opts["extensions"] = extensions
 
     # get jinja2 bytecode caching settings and set up bytecaching

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -205,6 +205,17 @@ class Test_parse_env_options_from_settings(unittest.TestCase):
         opts = self._callFUT(settings, "j2.")
         self.assertEqual(opts["undefined"], Undefined)
 
+    def test_default_extensions(self):
+        opts = self._callFUT({}, "j2.")
+        self.assertEqual(opts["extensions"], ["jinja2.ext.i18n"])
+
+    def test_override_i18n_extension(self):
+        settings = {
+            "j2.i18n_extension": "test.TestI18NExtension",
+        }
+        opts = self._callFUT(settings, "j2.")
+        self.assertEqual(opts["extensions"], ["test.TestI18NExtension"])
+
 
 # This is just a fake top level name that we can pass into maybe_dotted that
 # will resolve.


### PR DESCRIPTION
This pull request makes it possible to use a custom implementation/subclass for the i18n extension, rather than the default of `jinja2.ext.i18n`.